### PR TITLE
Add support for ACF oEmbed

### DIFF
--- a/wp-youtube-nocookie.php
+++ b/wp-youtube-nocookie.php
@@ -16,10 +16,14 @@ final class WP_Youtube_No_Cookie {
 	public function __construct() {
 		add_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ] );
 		add_filter( 'the_content', [ $this, 'filter_the_content' ], 100 );
+
+		if ( class_exists( 'ACF' ) ) {
+			add_filter( 'acf/format_value/type=oembed', [ $this, 'filter_acf_oembed' ], 100, 3);
+		}
 	}
 
 	/**
-	 * Modify the oEmbed HTMl.
+	 * Modify the oEmbed HTML.
 	 */
 	public function filter_embed_oembed_html( $html ) {
 		if ( str_contains( $html, 'youtube.com' ) ) {
@@ -36,6 +40,18 @@ final class WP_Youtube_No_Cookie {
 			$content = str_replace( 'youtube.com/embed', 'youtube-nocookie.com/embed', $content );
 		}
 		return $content;
+	}
+
+	/**
+	 * Modify ACF oEmbed field.
+	 */
+	public function filter_acf_oembed( $value, $post_id, $field ) {
+		if ( str_contains( $value, 'youtube.com' ) ) {
+			$value = str_replace( 'youtube.com', 'youtube-nocookie.com', $value );
+		} else if ( str_contains( $value, 'youtu.be' ) ) {
+			$value = str_replace( 'youtu.be/', 'www.youtube-nocookie.com/embed/', $value );
+		}
+		return $value;
 	}
 
 }


### PR DESCRIPTION
Add support for YouTube videos embedded through the ACF oEmbed field.

- Check if ACF is active before adding the filter.
- Replaces the domain to nocookie version.
- Also replaces youtu.be shortlinks (unlike core WP block, those don't get converted automatically)